### PR TITLE
Stabilize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VER := $(shell head -n 1 NEWS | cut -d : -f 1)
 all: regexfs
 
 regexfs: regexfs.c NEWS
-	$(CC) $(shell pkg-config fuse --cflags --libs) $(CFLAGS) -DVERSION=\"$(VER)\" $< -o $@
+	$(CC) $< -o $@ $(shell pkg-config fuse --cflags --libs) $(CFLAGS) -DVERSION=\"$(VER)\"
 
 install: all
 	install -D -m755 regexfs $(bindir)/regexfs


### PR DESCRIPTION
Previously it was assumed regexfs would run single threaded, this has been fixed as fuse operates concurrently. This required separate allocations of the match data, which subsequently also had to be freed correctly.
